### PR TITLE
Make translated articles worker more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arch-translator",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Useful tools for ArchWiki translators, now written in TypeScript.",
   "main": "index.js",
   "scripts": {

--- a/src/Tools/SidebarTools.ts
+++ b/src/Tools/SidebarTools.ts
@@ -138,6 +138,19 @@ export const changeActiveLanguageTool = (): CustomSidebarTool => {
     });
 };
 
+export const refreshTranslatedArticles = (): CustomSidebarTool => {
+    const handler = async () => {
+        alert('not implemented');
+    };
+
+    return sideTool({
+       name: "refresh-translated-articles",
+       displayText: "Refresh translated articles",
+       handler: handler
+    });
+};
+
 export const allSidebarTools = [
-    changeActiveLanguageTool(), copyCurrentRevisionIdTool(), copyEnglishRevisionIdTool(), createTranslationTool()
+    changeActiveLanguageTool(), copyCurrentRevisionIdTool(), copyEnglishRevisionIdTool(), createTranslationTool(),
+    refreshTranslatedArticles()
 ];

--- a/src/Tools/Workers/TranslatedArticlesWorker.ts
+++ b/src/Tools/Workers/TranslatedArticlesWorker.ts
@@ -108,9 +108,9 @@ export class TranslatedArticlesWorker {
 
         const findRedirectSource = (localizedLink: string): string => {
             const englishLink = removeLanguagePostfix(localizedLink);
-            if (englishLink === localizedLink) return localizedLink;
+            if (englishLink.toLowerCase() === localizedLink.toLowerCase()) return localizedLink;
 
-            const original = redirectsAndOther.find(r => r.redirectsTo === englishLink)!;
+            const original = redirectsAndOther.find(r => r.redirectsTo?.toLowerCase() === englishLink.toLowerCase())!;
             return original.link!;
         };
 

--- a/src/Tools/Workers/TranslatedArticlesWorker.ts
+++ b/src/Tools/Workers/TranslatedArticlesWorker.ts
@@ -80,6 +80,14 @@ export class TranslatedArticlesWorker {
         const linksWithPostfixes = parser
             .localizableLinks
             .map(l => localizeLink(l, language));
+        if (linksWithPostfixes.length <= 0) {
+            return {
+                existing: [],
+                notExisting: [],
+                redirects: []
+            };
+        }
+
         const info = await this._getPageInfosFor(linksWithPostfixes);
         console.debug(info.filter(i => i.exists));
 

--- a/src/Utilities/PageUtils.ts
+++ b/src/Utilities/PageUtils.ts
@@ -2,11 +2,17 @@ import {EditMessage, getMwApi} from "./MediaWikiJsApi";
 import {isTranslated, removeLanguagePostfix} from "../Internalization/I18nConstants";
 import {getPageContent} from "./Api/MediaWikiApiClient";
 import {getCachedPageInfo} from "../Storage/ScriptDb";
+import {CodeMirrorEditor} from "./CodeMirrorTypes";
 
 /**
  * Sometimes we do not need to fetch(...) for the raw page content (e.g. on edit pages).
  */
 let cachedPageContent: string|null = null;
+
+/**
+ * Storing the CodeMirror editor instance allows us to easily get it's current content
+ */
+let codeMirrorInstance: CodeMirrorEditor|null = null;
 
 export enum PageType {
     /**
@@ -129,10 +135,21 @@ export function cacheCurrentPageContent(content: string) {
     cachedPageContent = content;
 }
 
+/**
+ * Stores the CodeMirror editor instance
+ * @param cmEditor The editor instance
+ */
+export function storeCodeMirrorInstance(cmEditor: CodeMirrorEditor) {
+    codeMirrorInstance = cmEditor;
+}
+
 export async function getCurrentPageContent() {
-    if (cachedPageContent != null) {
+    if (codeMirrorInstance == null && cachedPageContent != null) {
         console.debug(`getCurrentPageContent: cache hit`);
         return cachedPageContent;
+    }
+    else if (codeMirrorInstance != null) {
+        return codeMirrorInstance.getValue();
     }
 
     const pageName = getMwApi()

--- a/src/Utilities/WikiTextParser.ts
+++ b/src/Utilities/WikiTextParser.ts
@@ -253,12 +253,17 @@ export class WikiTextParser {
  * @return string|null Redirect target page name or null if the content is not a redirect page
  */
 export const findRedirect = (wikiText: string): WikiLink|null => {
-    if (!wikiText.startsWith("#REDIRECT")) {
+    const prefix = "#REDIRECT ";
+    if (wikiText.length < prefix.length) {
+        return null;
+    }
+    const probablePrefix = wikiText.substring(0, prefix.length);
+    if (probablePrefix.toUpperCase() != prefix) {
         return null;
     }
 
     const linkText = wikiText
-        .substring("#REDIRECT ".length)
+        .substring(prefix.length)
         .trim();
     return new WikiLink(linkText);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,13 @@ import {getMwApi} from "./Utilities/MediaWikiJsApi";
 import {ToolManager} from "./Tools/Utils/ToolManager";
 import {allSidebarTools} from "./Tools/SidebarTools";
 import {getCachedPageInfo, getCurrentLanguage, setCachedPageInfo, setupDb} from "./Storage/ScriptDb";
-import {cacheCurrentPageContent, getCurrentPageContent, getCurrentPageInfo, PageType} from "./Utilities/PageUtils";
+import {
+    cacheCurrentPageContent,
+    getCurrentPageContent,
+    getCurrentPageInfo,
+    PageType,
+    storeCodeMirrorInstance
+} from "./Utilities/PageUtils";
 import {cacheCurrentPage} from "./Tools/CurrentPageDumper";
 import {CodeMirrorEditor} from "./Utilities/CodeMirrorTypes";
 import {NewArticleWorker} from "./Tools/Workers/NewArticleWorker";
@@ -70,6 +76,7 @@ setupDb()
 
                 // @ts-ignore
                 const cmEditor = codeMirrorElement.get()[0].CodeMirror as CodeMirrorEditor;
+                storeCodeMirrorInstance(cmEditor);
                 cacheCurrentPageContent(cmEditor.getValue());
 
                 const pageInfo = getCurrentPageInfo();

--- a/src/uscript-header.txt
+++ b/src/uscript-header.txt
@@ -3,7 +3,7 @@
 // @namespace   bb89542e-b358-4be0-8c01-3797d1f3a1e3
 // @match       https://wiki.archlinux.org/*
 // @grant       none
-// @version     2.0.3
+// @version     2.0.4
 // @author      bonk-dev
 // @description Useful tools for ArchWiki translators, now written in TypeScript.
 // @icon        https://gitlab.archlinux.org/uploads/-/system/group/avatar/23/iconfinder_archlinux_386451.png


### PR DESCRIPTION
Now you can manually refresh the translated articles table (closes #3).
It doesn't crash anymore when you open a redirect page that starts with lowercase "#redirect" instead of "#REDIRECT" (closes #2).